### PR TITLE
Updating worker.py to be inline with redis==3.2.1 and rq==1.0

### DIFF
--- a/rq_win/worker.py
+++ b/rq_win/worker.py
@@ -42,7 +42,12 @@ class WindowsWorker(rq.Worker):
         """
         self.log.info('Using rq_win.WindowsWorker (experimental)')
         self.default_worker_ttl=2
-        return super(WindowsWorker, self).work(burst)
+        return super(WindowsWorker, self).work(
+            burst=burst,
+            logging_level=logging_level,
+            date_format=date_format,
+            log_format=log_format,
+        )
 
 
     def execute_job(self, job, queue):


### PR DESCRIPTION
Quick update to support rq==1.0.

Tested on my machine and now works successfully -- so thanks to the people who came before me!

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>